### PR TITLE
Update SlackPerson

### DIFF
--- a/_slack/person.py
+++ b/_slack/person.py
@@ -75,24 +75,24 @@ class SlackPerson(Person):
     @property
     def channelname(self):
         """Convert a Slack channel ID to its channel name"""
-        if self._channelid is None:
+        if self.channelid is None:
             return None
 
         if self._channelname:
             return self._channelname
 
-        channel = [
-            channel
-            for channel in self._webclient.conversations_list()["channels"]
-            if channel["id"] == self._channelid
-        ]
+        channel = self._webclient.conversations_info(channel=self.channelid)
 
-        if not channel:
+        if not channel or not channel['ok']:
             raise RoomDoesNotExistError(
                 f"No channel with ID {self._channelid} exists."
             )
+        channel = channel['channel']
 
-        self._channelname = channel[0]["name"]
+        if channel['is_im']:
+            self._channelname = channel["user"]
+        else:
+            self._channelname = channel["name"]
         return self._channelname
 
     @property


### PR DESCRIPTION
- PEP8 validation
- Store all `user["profile"]` data instead of only specific data
- Simplify call `_get_user_info` and return generic data
- ACL will check against userid instead of username, as per Slack recomendation (username is meant to be deprecated but kept for legacy reasons)
- Get `channelname` from `conversations.info` instead of `conversations.list`