### PR TITLE
Revert "Ignore app_mention on public channels"

### DIFF
--- a/slackv3.py
+++ b/slackv3.py
@@ -659,10 +659,6 @@ class SlackBackend(ErrBot):
             text = event.get("text", "")
             user = event.get("user", event.get("bot_id"))
 
-        if (event['type'] == 'app_mention' and not event['channel'].startswith('G')):
-            log.debug('Ignoring app_mention event on non-private channel, message event will handle it.')
-            return
-
         text, mentioned = self.process_mentions(text)
 
         text = self.sanitize_uris(text)


### PR DESCRIPTION
Reverts nzlosh/err-backend-slackv3#13

The PR caused the bot to stop responding to RTM messages.  Here is an example of an event that cause an exception when handling the message:

```
{
	'client_msg_id': '48d50bb2-47a1-4dc9-92c5-33e78aa5e423',
	'suppress_notification': False,
	'text': '.b uptime',
	'user': 'Uxxxxxxx1',
	'team': 'Txxxxxxx1',
	'blocks': [{
		'type': 'rich_text',
		'block_id': '0/=',
		'elements': [{
			'type': 'rich_text_section',
			'elements': [{
				'type': 'text',
				'text': '.b uptime'
			}]
		}]
	}],
	'source_team': 'Txxxxxxx1',
	'user_team': 'Txxxxxxx1',
	'channel': 'Cxxxxxxx1',
	'event_ts': '1612374536.007300',
	'ts': '1612374536.007300'
}
```